### PR TITLE
ci: weekly Release and deploy schedule (Monday 04:00 UTC)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 # CD — semantic-release on master push, then GHCR build, staging validate, prod swap.
 # Production deploys at most every 6 hours when master has undeployed commits (push may
-# defer; cron catches up). workflow_dispatch always deploys immediately.
+# defer; weekly Monday 04:00 UTC cron catches up). workflow_dispatch always deploys immediately.
 name: Release and deploy
 
 concurrency:
@@ -11,7 +11,7 @@ on:
     push:
         branches: [master]
     schedule:
-        - cron: "0 */6 * * *"
+        - cron: "0 4 * * 1"
     workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Updates the automatic **Release and deploy** schedule in `.github/workflows/deploy.yml`.

- Previous cron: every 6 hours (`0 */6 * * *`)
- New cron: Mondays at 04:00 UTC (`0 4 * * 1`)

Push-triggered deploys (with the existing 6-hour cadence gate) and manual `workflow_dispatch` are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab4c9a3d-ceb5-4bf6-a679-115c1a2e9022?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab4c9a3d-ceb5-4bf6-a679-115c1a2e9022&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

